### PR TITLE
feat: added cyrillic to regex

### DIFF
--- a/src/TextChain.js
+++ b/src/TextChain.js
@@ -71,7 +71,7 @@ class TextChain {
   _nGramBeginsSentence(nGramKey) {
     const firstChar = nGramKey.substring(0, 1);
     const lastChar = nGramKey.substring(nGramKey.length - 1, nGramKey.length);
-    const regexUpper = /[A-Z]/;
+    var regexUpper = /[A-Z|А-Я]/;
     const regexPunctuation = /[!-.:-@[-`{-~‘-”]/;
 
     if (!firstChar.match(regexUpper) || lastChar.match(regexPunctuation)) {


### PR DESCRIPTION
Hi there! 
I encountered a small bug in a package. 
When regexp couldn't match any uppercase letter (which, in my case, happened with cyrillic strings), it threw an error, even if the actual strings were fine. 

I made a small adaptation to regex so it could match with cyrillic. 

Best regards, 
Vladimir 